### PR TITLE
Fix 'stream' circular dependency...

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 import 'babel-core/polyfill'
+import 'stream-browserify'  // import early to avoid 'stream' dependency cycle
 import React from 'react'
 import { render } from 'react-dom'
 import { Provider } from 'react-redux'


### PR DESCRIPTION
Import 'pouch-websocket-sync' leads to requiring 'stream'.
In the browser, 'stream' is supplied by 'node-libs-browser'
requiring 'stream-browserify'.

Unfortunately, 'stream-browserify' ultimately requires 'stream' again.
(This is to inherit from an exiting definition when one is present.)
When webpack encounters this circle, it eventually returns an empty object,
supplying an unfulfilled dependency.
This is how CommonJS is supposed to work when encountering a cycle.
(Node would behave the same if 'stream' were not built in.)

Importing 'stream-browserify' early, before any module requires 'stream',
creates the base modules before they can get caught in a dependency cycle.
This way those module are present when other modules try to import 'stream'.

More details of this cycle problem are recorded in [readable-stream issue 237]
(https://github.com/nodejs/readable-stream/issues/237) and
[webpack issue 4378](https://github.com/webpack/webpack/issues/4378).
The behavior of webpack in this scenario appears to be as expected.